### PR TITLE
simulation-gazebo: go from version 6 to 7 on Linux

### DIFF
--- a/book/simulation-gazebo.md
+++ b/book/simulation-gazebo.md
@@ -17,7 +17,7 @@ graph LR;
 The installation requires to install Gazebo and our simulation plugin.
 
 <aside class="tip">
-Gazebo version 6 should be used. Linux users: If you installed a ROS version earlier than Jade, be sure to uninstall the bundled Gazebo (sudo apt-get remove ros-indigo-gazebo) version as it is too old.
+Gazebo version 7 should be used. Linux users: If you installed a ROS version earlier than Jade, be sure to uninstall the bundled Gazebo (sudo apt-get remove ros-indigo-gazebo) version as it is too old.
 </aside>
 
 ### Mac OS
@@ -36,11 +36,11 @@ The PX4 SITL uses the Gazebo simulator, but does not depend on ROS. The simulati
 
 #### ROS Users
 
-If you plan to use PX4 with ROS, make sure to follow the [Gazebo version guide for version 6](http://gazebosim.org/tutorials?tut=ros_wrapper_versions#Gazebo6.xseries) for ROS.
+If you plan to use PX4 with ROS, make sure to follow the [Gazebo version guide for version 7](http://gazebosim.org/tutorials?tut=ros_wrapper_versions#Gazebo7.xseries) for ROS.
 
 #### Normal Installation
 
-Follow the [Linux installation instructions](http://gazebosim.org/tutorials?tut=install_ubuntu&ver=6.0&cat=install) for Gazebo 6.
+Follow the [Linux installation instructions](http://gazebosim.org/tutorials?cat=install&tut=install_ubuntu&ver=7.0) for Gazebo 7.
 
 ## Running the Simulation
 


### PR DESCRIPTION
These instructions work on Ubuntu 15.10. 

In my setup, I have ROS compiled from source, so I'm not sure if/how this would work together with ROS from deps.